### PR TITLE
Récupération de la liste des symptomes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+Project02Eclipse.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-Project02Eclipse.iml
+symptoms-analytics.iml

--- a/src/com/hemebiotech/analytics/AnalyticsCounter.java
+++ b/src/com/hemebiotech/analytics/AnalyticsCounter.java
@@ -5,39 +5,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 
 public class AnalyticsCounter {
-	private static int headacheCount = 0;	// initialize to 0
-	private static int rashCount = 0;		// initialize to 0
-	private static int pupilCount = 0;		// initialize to 0
-	
 	public static void main(String args[]) throws Exception {
-		// first get input
-		BufferedReader reader = new BufferedReader (new FileReader("symptoms.txt"));
-		String line = reader.readLine();
 
-		int i = 0;	// set i to 0
-		int headCount = 0;	// counts headaches
-		while (line != null) {
-			i++;	// increment i
-			System.out.println("symptom from file: " + line);
-			if (line.equals("headache")) {
-				headCount++;
-				System.out.println("number of headaches: " + headCount);
-			}
-			else if (line.equals("rush")) {
-				rashCount++;
-			}
-			else if (line.contains("pupils")) {
-				pupilCount++;
-			}
-
-			line = reader.readLine();	// get another symptom
-		}
-		
-		// next generate output
-		FileWriter writer = new FileWriter ("result.out");
-		writer.write("headache: " + headacheCount + "\n");
-		writer.write("rash: " + rashCount + "\n");
-		writer.write("dialated pupils: " + pupilCount + "\n");
-		writer.close();
 	}
 }

--- a/src/com/hemebiotech/analytics/AnalyticsCounter.java
+++ b/src/com/hemebiotech/analytics/AnalyticsCounter.java
@@ -1,11 +1,7 @@
 package com.hemebiotech.analytics;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.FileWriter;
-
 public class AnalyticsCounter {
-	public static void main(String args[]) throws Exception {
+	public static void main(String args[]) {
 
 	}
 }

--- a/src/com/hemebiotech/analytics/AnalyticsCounter.java
+++ b/src/com/hemebiotech/analytics/AnalyticsCounter.java
@@ -1,7 +1,11 @@
 package com.hemebiotech.analytics;
 
+import java.util.List;
+
 public class AnalyticsCounter {
 	public static void main(String args[]) {
-
+		//lecture des symptomes
+		ISymptomReader symptomReader = new ReadSymptomDataFromFile("symptoms.txt");
+		List<String> symptoms = symptomReader.getSymptoms();
 	}
 }

--- a/src/com/hemebiotech/analytics/AnalyticsCounter.java
+++ b/src/com/hemebiotech/analytics/AnalyticsCounter.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class AnalyticsCounter {
 	public static void main(String args[]) {
-		//lecture des symptomes
+		// Lecture des symptomes
 		ISymptomReader symptomReader = new ReadSymptomDataFromFile("symptoms.txt");
 		List<String> symptoms = symptomReader.getSymptoms();
 	}

--- a/src/com/hemebiotech/analytics/ISymptomReader.java
+++ b/src/com/hemebiotech/analytics/ISymptomReader.java
@@ -16,5 +16,5 @@ public interface ISymptomReader {
 	 * 
 	 * @return a raw listing of all Symptoms obtained from a data source, duplicates are possible/probable
 	 */
-	List<String> GetSymptoms ();
+	List<String> getSymptoms();
 }

--- a/src/com/hemebiotech/analytics/ReadSymptomDataFromFile.java
+++ b/src/com/hemebiotech/analytics/ReadSymptomDataFromFile.java
@@ -23,7 +23,7 @@ public class ReadSymptomDataFromFile implements ISymptomReader {
 	}
 	
 	@Override
-	public List<String> GetSymptoms() {
+	public List<String> getSymptoms() {
 		ArrayList<String> result = new ArrayList<String>();
 		
 		if (filepath != null) {


### PR DESCRIPTION
- Nettoyage du code afin d'aller sur de nouvelles bases ;
- Ignorer les fichiers de configuration de l'IDE en utilisant `.gitignore` ;
- Renommer la méthode `getSymptoms ` de l'interface `ISymptomReader `afin de respecter la nomenclature Java ;
- Utilisation de l'interface et de la classe pour récupérer la liste des symptomes dans `AnalyticsCounter`.